### PR TITLE
teshari radiation suit fix

### DIFF
--- a/code/modules/clothing/suits/utility.dm
+++ b/code/modules/clothing/suits/utility.dm
@@ -109,6 +109,7 @@
 	icon_override = 'icons/inventory/suit/mob_teshari.dmi'
 	icon_state = "rad_fitted"
 	species_restricted = list(SPECIES_TESHARI)
+	slowdown = 0.5 //standardizes slowdown to align with normal suit for teshari Chompedit
 
 /obj/item/clothing/head/radiation/teshari
 	name = "Small radiation hood"


### PR DESCRIPTION

## About The Pull Request
## Changelog
:cl:

qol: made something easier to use
 Makes teshari radsuit slowdown match the normal radsuit slowdown. As teshari are doubly affected by the slowdown modifier. This item needs a reason to exist. 
Not done - change the helmet item icon to match the normal radsuit helmet in hand and on floor. - Help doing this would be lovely.
/:cl:
